### PR TITLE
.then chain should return to create event

### DIFF
--- a/db/seeds/1-add-events.js
+++ b/db/seeds/1-add-events.js
@@ -11,7 +11,7 @@ exports.seed = (knex) => {
       ]);
     })
     .then(() => {
-      knex("event")
+      return knex("event")
         .then(() => {
           return knex("event").insert([
             {


### PR DESCRIPTION
It breaks seeding, if not returned, event is not being created and an error happens while creating a bet for that event (which was not created)